### PR TITLE
server/internal/manifest: fix typo in godoc comment

### DIFF
--- a/server/internal/manifest/manifest.go
+++ b/server/internal/manifest/manifest.go
@@ -104,7 +104,7 @@
 //
 // # Legacy Media Types
 //
-// The appliaction/vnd.ollama.image.model media type is deprecated, but will
+// The application/vnd.ollama.image.model media type is deprecated, but will
 // remain supported for backwards compatibility, for some undefined amount of
 // time. New models should use the media types defined above.
 //


### PR DESCRIPTION
## Summary

Fix typo "appliaction" → "application" in the Legacy Media Types godoc comment in `manifest.go`.

Fixes #1

## Changes

- Fixed spelling of "application" in line 107 of `server/internal/manifest/manifest.go`

## Testing

- Verified the change is cosmetic (comment-only) and does not affect compiled output

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in Legacy Media Types documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->