### PR TITLE
discover: fix typo in bootstrap timeout comment

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -87,7 +87,7 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 			if runtime.GOOS == "windows" {
 				// On Windows with Defender enabled, AV scanning of the DLLs
 				// takes place sequentially and this can significantly increase
-				// the time it takes too do the initial discovery pass.
+				// the time it takes to do the initial discovery pass.
 				// Subsequent loads will be faster as the scan results are
 				// cached
 				bootstrapTimeout = 90 * time.Second


### PR DESCRIPTION
## Summary

Fix grammatical typo "too do" → "to do" in the Windows Defender scan timeout comment in `discover/runner.go`.

Fixes #3

## Changes

- Fixed "too do" to "to do" in line 90 of `discover/runner.go`

## Testing

- Comment-only change, no functional impact

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed a typo in internal comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->