### PR TITLE
envconfig: fix inconsistent description for OLLAMA_FLASH_ATTENTION

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -280,7 +280,7 @@ type EnvVar struct {
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
 		"OLLAMA_DEBUG":             {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
-		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
+		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enable flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_HOST":              {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},


### PR DESCRIPTION
## Summary

Change the `OLLAMA_FLASH_ATTENTION` description from past tense "Enabled flash attention" to imperative "Enable flash attention", matching the convention used by all other env var descriptions.

Fixes #5

## Changes

- Changed description string from "Enabled flash attention" to "Enable flash attention" in `envconfig/config.go`

## Testing

- String-only change in description map, no functional impact

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.