### PR TITLE
server: fix extra space in deprecation comment

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -310,7 +310,7 @@ func GetModel(name string) (*Model, error) {
 			m.ModelPath = filename
 			m.ParentModel = layer.From
 		case "application/vnd.ollama.image.embed":
-			// Deprecated in versions  > 0.1.2
+			// Deprecated in versions > 0.1.2
 			// TODO: remove this warning in a future version
 			slog.Info("WARNING: model contains embeddings, but embeddings in modelfiles have been deprecated and will be ignored.")
 		case "application/vnd.ollama.image.adapter":


### PR DESCRIPTION
## Summary

Remove an extra space in the embeddings deprecation comment in `server/images.go`.

Fixes #7

## Changes

- Fixed double space "versions  >" to "versions >" in line 313

## Testing

- Comment-only change, no functional impact

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.