### PR TITLE
server: use slog.Warn for deprecation warning

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -312,7 +312,7 @@ func GetModel(name string) (*Model, error) {
 		case "application/vnd.ollama.image.embed":
 			// Deprecated in versions  > 0.1.2
 			// TODO: remove this warning in a future version
-			slog.Info("WARNING: model contains embeddings, but embeddings in modelfiles have been deprecated and will be ignored.")
+			slog.Warn("model contains embeddings, but embeddings in modelfiles have been deprecated and will be ignored")
 		case "application/vnd.ollama.image.adapter":
 			m.AdapterPaths = append(m.AdapterPaths, filename)
 		case "application/vnd.ollama.image.projector":


### PR DESCRIPTION
## Summary

The embeddings deprecation message was logged at `slog.Info` level with a manual "WARNING:" prefix. This changes it to `slog.Warn` so the message is correctly filtered by log level, and drops the redundant prefix string.

Fixes #9

## Changes

- Changed `slog.Info("WARNING: model contains embeddings...")` to `slog.Warn("model contains embeddings...")`

## Testing

- Verified `slog.Warn` is used elsewhere in the codebase for similar warnings
- No functional behavior change beyond correct log level classification

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.