### PR TITLE
integration: replace deprecated io/ioutil with os.ReadFile

### DIFF
--- a/integration/model_arch_test.go
+++ b/integration/model_arch_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -123,7 +122,7 @@ func TestModelsEmbed(t *testing.T) {
 		slog.Warn("No VRAM info available, testing all models, so larger ones might timeout...")
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "embed.json"))
+	data, err := os.ReadFile(filepath.Join("testdata", "embed.json"))
 	if err != nil {
 		t.Fatalf("failed to open test data file: %s", err)
 	}

--- a/integration/model_perf_test.go
+++ b/integration/model_perf_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log/slog"
 	"math"
 	"os"
@@ -71,7 +70,7 @@ func doModelPerfTest(t *testing.T, chatModels []string) {
 		slog.Warn("No VRAM info available, testing all models, so larger ones might timeout...")
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "shakespeare.txt"))
+	data, err := os.ReadFile(filepath.Join("testdata", "shakespeare.txt"))
 	if err != nil {
 		t.Fatalf("failed to open test data file: %s", err)
 	}


### PR DESCRIPTION
## Summary

Replace deprecated `io/ioutil` package usage with `os.ReadFile` in integration test files. The `io/ioutil` package was deprecated in Go 1.16.

Fixes #13

## Changes

- `integration/model_perf_test.go`: replaced `ioutil.ReadFile` with `os.ReadFile`, removed `io/ioutil` import
- `integration/model_arch_test.go`: replaced `ioutil.ReadFile` with `os.ReadFile`, removed `io/ioutil` import

## Testing

- Both files already import `"os"`, so no new imports needed
- `os.ReadFile` is a drop-in replacement for `ioutil.ReadFile`

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test utilities to use modern standard library functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->