### PR TITLE
openai: add godoc comment to exported NewError function

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -215,6 +215,8 @@ type EmbeddingUsage struct {
 	TotalTokens  int `json:"total_tokens"`
 }
 
+// NewError creates an ErrorResponse with the appropriate error type for the
+// given HTTP status code and message.
 func NewError(code int, message string) ErrorResponse {
 	var etype string
 	switch code {


### PR DESCRIPTION
## Summary

Add a missing godoc comment to the exported `NewError` function in `openai/openai.go`. All other exported functions in this file have documentation comments.

Fixes #17

## Changes

- Added godoc comment to `NewError` describing its purpose

## Testing

- Documentation-only change, no functional impact

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.