### PR TITLE
discover: cancel context per loop iteration instead of deferring

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -112,10 +112,10 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 			}
 
 			ctx1stPass, cancel := context.WithTimeout(ctx, bootstrapTimeout)
-			defer cancel()
 
 			// For this pass, we retain duplicates in case any are incompatible with some libraries
 			devices = append(devices, bootstrapDevices(ctx1stPass, dirs, nil)...)
+			cancel()
 		}
 
 		// In the second pass, we more deeply initialize the GPUs to weed out devices that


### PR DESCRIPTION
## Summary

Fix a resource leak where `defer cancel()` inside a `for` loop caused timeout contexts to accumulate until the enclosing function returned, rather than being cleaned up after each iteration.

Fixes #19

## Changes

- Replaced `defer cancel()` with an explicit `cancel()` call after `bootstrapDevices` returns, ensuring each context is released promptly at the end of its loop iteration

## Testing

- In Go, `defer` is scoped to the function, not the block. The previous code would hold all contexts open until `GPUDevices` returned. The fix calls `cancel()` directly after use, which is the standard Go pattern for contexts created in loops.

## Disclosure

This contribution was developed with AI assistance (Claude Code).
All changes have been reviewed and tested before submission.